### PR TITLE
[modif] Modify Duration import + change delay size u64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ readme = "README.md"
 
 [dependencies]
 embedded-hal = "0.2.5"
+embedded-time = "0.12.1"
 nb = "1.0.0"
 


### PR DESCRIPTION
I wanted to use your crate with STM32f303 board, but I was blocked with the import Duration from core::time. core::time::Duration is not compatible with a Timer in STM32f3xx_hal. May be it is compatible with SYSTick but on my case Systick is already used. 

I made some changes to be able to use your crate with STM32 Timer.  I can't check with the display due to voltage intolerance. I have to adapt voltage between MCU and display, but observing signals with logic analyser the delays seems be repected with delay implemented from embedded_hal Duration

I hope but note sure this pull request is generic method and easy to port on other hardware. 
Could your check on your hardware if the proposal implementation works ? 